### PR TITLE
Fix socket warnings

### DIFF
--- a/congress.py
+++ b/congress.py
@@ -81,9 +81,13 @@ class Client(object):
     
     BASE_URI = "https://api.propublica.org/congress/v1/"
     
-    def __init__(self, apikey=None, cache='.cache'):
+    def __init__(self, apikey=None, cache='.cache', http=None):
         self.apikey = apikey
-        self.http = httplib2.Http(cache)
+
+        if isinstance(http, httplib2.Http):
+            self.http = http
+        else:
+            self.http = httplib2.Http(cache)
     
     def fetch(self, path, parse=lambda r: r['results'][0]):
         """
@@ -361,12 +365,13 @@ class Congress(Client):
     same interface as FileCache (per httplib2 docs).
     """
     
-    def __init__(self, apikey=os.environ.get('PROPUBLICA_API_KEY'), cache='.cache'):
-        super(Congress, self).__init__(apikey, cache)
-        self.members = MembersClient(self.apikey, cache)
-        self.bills = BillsClient(self.apikey, cache)
-        self.committees = CommitteesClient(self.apikey, cache)
-        self.votes = VotesClient(self.apikey, cache)
-        self.nominations = NominationsClient(self.apikey, cache)
+    def __init__(self, apikey=os.environ.get('PROPUBLICA_API_KEY'), cache='.cache', http=None):
+        super(Congress, self).__init__(apikey, cache, http)
+
+        self.members = MembersClient(self.apikey, cache, self.http)
+        self.bills = BillsClient(self.apikey, cache, self.http)
+        self.committees = CommitteesClient(self.apikey, cache, self.http)
+        self.votes = VotesClient(self.apikey, cache, self.http)
+        self.nominations = NominationsClient(self.apikey, cache, self.http)
 
 

--- a/test.py
+++ b/test.py
@@ -13,6 +13,11 @@ from congress import Congress, CongressError, NotFound, get_congress, u
 
 API_KEY = os.environ['PROPUBLICA_API_KEY']
 
+def close_connections(http):
+    for k, conn in http.connections.items():
+        conn.close()
+
+
 class APITest(unittest.TestCase):
     
     def check_response(self, result, url, parse=lambda r: r['results'][0]):
@@ -31,7 +36,8 @@ class APITest(unittest.TestCase):
         self.http = httplib2.Http()
 
     def tearDown(self):
-        pass
+        close_connections(self.congress.http)
+        close_connections(self.http)
     
 class MemberTest(APITest):
 


### PR DESCRIPTION
Share one http instance between all subclients, and close all connections after each test. Closes #12 