### PR TITLE
Crucial: fix package install. Other minor updates

### DIFF
--- a/congress/bills.py
+++ b/congress/bills.py
@@ -56,3 +56,8 @@ class BillsClient(Client):
     def major(self, chamber, congress=CURRENT_CONGRESS):
         "Shortcut for major bills"
         return self.recent(chamber, congress, 'major')
+
+    def upcoming(self, chamber, congress=CURRENT_CONGRESS):
+        "Shortcut for upcoming bills"
+        path = "bills/upcoming/{chamber}.json".format(chamber=chamber)
+        return self.fetch(path)

--- a/congress/client.py
+++ b/congress/client.py
@@ -52,6 +52,9 @@ class Client(object):
             if "errors" in content and content['errors'][0]['error'] == "Record not found":
                 raise NotFound(path)
 
+            if content.get('status') == '404':
+                raise NotFound(path)
+
             raise CongressError(content, resp, url)
 
         if callable(parse):

--- a/congress/utils.py
+++ b/congress/utils.py
@@ -35,7 +35,7 @@ def get_congress(year):
     if year < 1789:
         raise CongressError('There was no Congress before 1789.')
 
-    return math.floor((year - 1789) / 2 + 1)
+    return int(math.floor((year - 1789) / 2 + 1))
 
 
 def parse_date(s):

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup, find_packages
 
 
 with open('README.rst') as f:
@@ -13,14 +10,14 @@ VERSION = "0.3.4"
 
 setup(
     name = "python-congress",
+    packages=find_packages(exclude=['docs']),
     version = VERSION,
     description = "A Python client for the ProPublica Congress API",
     long_description = README,
     author = "Chris Amico",
     author_email = "eyeseast@gmail.com",
-    py_modules = ['congress'],
+    url = 'https://github.com/eyeseast/propublica-congress',
     install_requires = ['httplib2', 'six'],
-    platforms= ['any'],
     classifiers = [
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
**Summary:**
* Fix pip install (really important)
* Add support for upcoming bills (just added to ProPublica API Sept 3rd: https://github.com/propublica/congress-api-docs/issues/8)
* Handle new 404 response format
* Force congress number to always be an integer (fixes default behavior)

For me, the pip install wasn't generating the `congress` directory, so `from congress import Congress` failed. Feel free to fix this a different way, but this was my fix. Works now with:
```
pip install git+git://github.com/UpliftAgency/propublica-congress.git@3ffa3e0#egg=propublica_congress
```