### PR TITLE
PEP8 Compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Visual Studio Files
+.vs/

--- a/congress/__init__.py
+++ b/congress/__init__.py
@@ -18,30 +18,31 @@ from .committees import CommitteesClient
 from .votes import VotesClient
 from .nominations import NominationsClient
 
+
 __all__ = ('Congress', 'CongressError', 'NotFound', 'get_congress', 'CURRENT_CONGRESS')
 
 
 class Congress(Client):
     """
     Implements the public interface for the ProPublica Congress API
-    
+
     Methods are namespaced by topic (though some have multiple access points).
     Everything returns decoded JSON, with fat trimmed.
-    
+
     In addition, the top-level namespace is itself a client, which
     can be used to fetch generic resources, using the API URIs included
     in responses. This is here so you don't have to write separate
     functions that add on your API key and trim fat off responses.
-    
+
     Create a new instance with your API key, or set an environment
     variable called ``PROPUBLICA_API_KEY``.
-    
+
     Congress uses `httplib2 <https://github.com/httplib2/httplib2>`_, and caching is pluggable. By default,
-    it uses `httplib2.FileCache <https://httplib2.readthedocs.io/en/latest/libhttplib2.html#httplib2.FileCache>`_, 
-    in a directory called ``.cache``, but it should also work with memcache 
+    it uses `httplib2.FileCache <https://httplib2.readthedocs.io/en/latest/libhttplib2.html#httplib2.FileCache>`_,
+    in a directory called ``.cache``, but it should also work with memcache
     or anything else that exposes the same interface as FileCache (per httplib2 docs).
     """
-    
+
     def __init__(self, apikey=None, cache='.cache', http=None):
         if apikey is None:
             apikey = os.environ.get('PROPUBLICA_API_KEY')
@@ -53,4 +54,3 @@ class Congress(Client):
         self.members = MembersClient(self.apikey, cache, self.http)
         self.nominations = NominationsClient(self.apikey, cache, self.http)
         self.votes = VotesClient(self.apikey, cache, self.http)
-

--- a/congress/bills.py
+++ b/congress/bills.py
@@ -3,15 +3,17 @@ from .utils import CURRENT_CONGRESS, check_chamber
 
 
 class BillsClient(Client):
-    
+
     def by_member(self, member_id, type='introduced'):
         """
-        Takes a bioguide ID and a type (introduced|updated|cosponsored|withdrawn), 
-        returns recent bills
+        Takes a bioguide ID and a type:
+        (introduced|updated|cosponsored|withdrawn)
+        Returns recent bills
         """
-        path = "members/{member_id}/bills/{type}.json".format(member_id=member_id, type=type)
+        path = "members/{member_id}/bills/{type}.json".format(
+            member_id=member_id, type=type)
         return self.fetch(path)
-    
+
     def get(self, bill_id, congress=CURRENT_CONGRESS, type=None):
         if type:
             path = "{congress}/bills/{bill_id}/{type}.json".format(
@@ -21,30 +23,34 @@ class BillsClient(Client):
                 congress=congress, bill_id=bill_id)
 
         return self.fetch(path)
-    
+
     def amendments(self, bill_id, congress=CURRENT_CONGRESS):
         return self.get(bill_id, congress, 'amendments')
 
     def related(self, bill_id, congress=CURRENT_CONGRESS):
         return self.get(bill_id, congress, 'related')
-    
+
     def subjects(self, bill_id, congress=CURRENT_CONGRESS):
         return self.get(bill_id, congress, 'subjects')
-    
+
     def cosponsors(self, bill_id, congress=CURRENT_CONGRESS):
         return self.get(bill_id, congress, 'cosponsors')
-    
+
     def recent(self, chamber, congress=CURRENT_CONGRESS, type='introduced'):
         check_chamber(chamber)
-        "Takes a chamber, Congress, and type (introduced|updated), returns a list of recent bills"
+        """
+        Takes a chamber, Congress, and type:
+        (introduced|updated)
+        Returns a list of recent bills
+        """
         path = "{congress}/{chamber}/bills/{type}.json".format(
             congress=congress, chamber=chamber, type=type)
         return self.fetch(path)
-    
+
     def introduced(self, chamber, congress=CURRENT_CONGRESS):
         "Shortcut for getting introduced bills"
         return self.recent(chamber, congress, 'introduced')
-    
+
     def updated(self, chamber, congress=CURRENT_CONGRESS):
         "Shortcut for getting updated bills"
         return self.recent(chamber, congress, 'updated')

--- a/congress/client.py
+++ b/congress/client.py
@@ -12,13 +12,14 @@ log = logging.getLogger('congress')
 
 class Client(object):
     """
-    Client classes deal with fetching responses from the ProPublica Congress API
-    and parsing what comes back. In addition to storing API credentials, a client
-    can use a custom cache, or even a customized httplib2.Http instance.
+    Client classes deal with fetching responses from the ProPublica Congress
+    API and parsing what comes back. In addition to storing API credentials,
+    a client can use a custom cache, or even a customized
+    httplib2.Http instance.
     """
-    
+
     BASE_URI = "https://api.propublica.org/congress/v1/"
-    
+
     def __init__(self, apikey=None, cache='.cache', http=None):
         self.apikey = apikey
 
@@ -26,12 +27,13 @@ class Client(object):
             self.http = http
         else:
             self.http = httplib2.Http(cache)
-    
+
     def fetch(self, path, parse=lambda r: r['results'][0]):
         """
         Make an API request, with authentication.
 
-        This method can be used directly to fetch new endpoints or customize parsing.
+        This method can be used directly to fetch new endpoints
+        or customize parsing.
 
         ::
 
@@ -46,7 +48,7 @@ class Client(object):
         headers = {'X-API-Key': self.apikey}
 
         log.debug(url)
-        
+
         resp, content = self.http.request(url, headers=headers)
         content = u(content)
         content = json.loads(content)

--- a/congress/committees.py
+++ b/congress/committees.py
@@ -3,13 +3,13 @@ from .utils import CURRENT_CONGRESS, check_chamber
 
 
 class CommitteesClient(Client):
-    
+
     def filter(self, chamber, congress=CURRENT_CONGRESS):
         check_chamber(chamber)
         path = "{congress}/{chamber}/committees.json".format(
             congress=congress, chamber=chamber)
         return self.fetch(path)
-    
+
     def get(self, chamber, committee, congress=CURRENT_CONGRESS):
         check_chamber(chamber)
         path = "{congress}/{chamber}/committees/{committee}.json".format(

--- a/congress/members.py
+++ b/congress/members.py
@@ -3,15 +3,15 @@ from .utils import CURRENT_CONGRESS, check_chamber
 
 
 class MembersClient(Client):
-    
+
     def get(self, member_id):
         "Takes a bioguide_id, returns a legislator"
         path = "members/{0}.json".format(member_id)
         return self.fetch(path)
-    
+
     def filter(self, chamber, congress=CURRENT_CONGRESS, **kwargs):
         """
-        Takes a chamber and Congress, 
+        Takes a chamber and Congress,
         OR state and district, returning a list of members
         """
         check_chamber(chamber)
@@ -19,32 +19,35 @@ class MembersClient(Client):
         kwargs.update(chamber=chamber, congress=congress)
 
         if 'state' in kwargs and 'district' in kwargs:
-            path = "members/{chamber}/{state}/{district}/current.json".format(**kwargs)
+            path = ("members/{chamber}/{state}/{district}/"
+                    "current.json").format(**kwargs)
 
         elif 'state' in kwargs:
-            path = "members/{chamber}/{state}/current.json".format(**kwargs)
+            path = ("members/{chamber}/{state}/"
+                    "current.json").format(**kwargs)
 
         else:
-            path = "{congress}/{chamber}/members.json".format(**kwargs)
+            path = ("{congress}/{chamber}/"
+                    "members.json").format(**kwargs)
 
         return self.fetch(path, parse=lambda r: r['results'])
-    
+
     def bills(self, member_id, type='introduced'):
         "Same as BillsClient.by_member"
         path = "members/{0}/bills/{1}.json".format(member_id, type)
         return self.fetch(path)
-    
+
     def new(self, **kwargs):
         "Returns a list of new members"
         path = "members/new.json"
         return self.fetch(path)
-    
+
     def departing(self, chamber, congress=CURRENT_CONGRESS):
         "Takes a chamber and congress and returns a list of departing members"
         check_chamber(chamber)
         path = "{0}/{1}/members/leaving.json".format(congress, chamber)
         return self.fetch(path)
-    
+
     def compare(self, first, second, chamber, type='votes', congress=CURRENT_CONGRESS):
         """
         See how often two members voted together in a given Congress.
@@ -52,8 +55,8 @@ class MembersClient(Client):
         """
         check_chamber(chamber)
         path = "members/{first}/{type}/{second}/{congress}/{chamber}.json"
-        path = path.format(first=first, second=second, 
-            type=type, congress=congress, chamber=chamber)
+        path = path.format(first=first, second=second, type=type,
+                           congress=congress, chamber=chamber)
         return self.fetch(path)
 
     def party(self):

--- a/congress/nominations.py
+++ b/congress/nominations.py
@@ -3,15 +3,17 @@ from .utils import CURRENT_CONGRESS
 
 
 class NominationsClient(Client):
-    
+
     def filter(self, type, congress=CURRENT_CONGRESS):
-        path = "{congress}/nominees/{type}.json".format(congress=congress, type=type)
+        path = "{congress}/nominees/{type}.json".format(congress=congress,
+                                                        type=type)
         return self.fetch(path)
-    
+
     def get(self, nominee, congress=CURRENT_CONGRESS):
-        path = "{congress}/nominees/{nominee}.json".format(congress=congress, nominee=nominee)
+        path = "{congress}/nominees/{nominee}.json".format(congress=congress,
+                                                           nominee=nominee)
         return self.fetch(path)
-    
+
     def by_state(self, state, congress=CURRENT_CONGRESS):
         path = "{congress}/nominees/state/{state}.json".format(
             congress=congress, state=state)

--- a/congress/utils.py
+++ b/congress/utils.py
@@ -6,7 +6,6 @@ import math
 import six
 
 
-
 class CongressError(Exception):
     """
     Exception for general Congress API errors

--- a/congress/votes.py
+++ b/congress/votes.py
@@ -5,7 +5,7 @@ from .utils import CURRENT_CONGRESS, check_chamber, parse_date
 
 
 class VotesClient(Client):
-    
+
     # date-based queries
     def by_month(self, chamber, year=None, month=None):
         """
@@ -16,11 +16,11 @@ class VotesClient(Client):
         now = datetime.datetime.now()
         year = year or now.year
         month = month or now.month
-        
+
         path = "{chamber}/votes/{year}/{month}.json".format(
             chamber=chamber, year=year, month=month)
         return self.fetch(path, parse=lambda r: r['results'])
-    
+
     def by_range(self, chamber, start, end):
         """
         Return votes cast in a chamber between two dates,
@@ -35,27 +35,29 @@ class VotesClient(Client):
         path = "{chamber}/votes/{start:%Y-%m-%d}/{end:%Y-%m-%d}.json".format(
             chamber=chamber, start=start, end=end)
         return self.fetch(path, parse=lambda r: r['results'])
-    
+
     def by_date(self, chamber, date):
         "Return votes cast in a chamber on a single day"
         date = parse_date(date)
         return self.by_range(chamber, date, date)
-    
+
     def today(self, chamber):
         "Return today's votes in a given chamber"
         now = datetime.date.today()
         return self.by_range(chamber, now, now)
-    
+
     # detail response
     def get(self, chamber, rollcall_num, session, congress=CURRENT_CONGRESS):
-        "Return a specific roll-call vote, including a complete list of member positions"
+        ("Return a specific roll-call vote, "
+         "including a complete list of member positions")
         check_chamber(chamber)
 
-        path = "{congress}/{chamber}/sessions/{session}/votes/{rollcall_num}.json"
-        path = path.format(congress=congress, chamber=chamber, 
-            session=session, rollcall_num=rollcall_num)
+        path = ("{congress}/{chamber}/sessions/{session}"
+                "/votes/{rollcall_num}.json")
+        path = path.format(congress=congress, chamber=chamber,
+                           session=session, rollcall_num=rollcall_num)
         return self.fetch(path, parse=lambda r: r['results'])
-    
+
     # votes by type
     def by_type(self, chamber, type, congress=CURRENT_CONGRESS):
         "Return votes by type: missed, party, lone no, perfect"
@@ -64,23 +66,23 @@ class VotesClient(Client):
         path = "{congress}/{chamber}/votes/{type}.json".format(
             congress=congress, chamber=chamber, type=type)
         return self.fetch(path)
-    
+
     def missed(self, chamber, congress=CURRENT_CONGRESS):
         "Missed votes by member"
         return self.by_type(chamber, 'missed', congress)
-    
+
     def party(self, chamber, congress=CURRENT_CONGRESS):
         "How often does each member vote with their party?"
         return self.by_type(chamber, 'party', congress)
-    
+
     def loneno(self, chamber, congress=CURRENT_CONGRESS):
         "How often is each member the lone no vote?"
         return self.by_type(chamber, 'loneno', congress)
-    
+
     def perfect(self, chamber, congress=CURRENT_CONGRESS):
         "Who never misses a vote?"
         return self.by_type(chamber, 'perfect', congress)
-    
+
     def nominations(self, congress=CURRENT_CONGRESS):
         "Return votes on nominations from a given Congress"
         path = "{congress}/nominations.json".format(congress=congress)

--- a/test.py
+++ b/test.py
@@ -65,7 +65,7 @@ class MemberTest(APITest):
         states = [
             ('RI', 2),
             ('AL', 7),
-            ('AZ', 9),
+            ('AZ', 8),
         ]
 
         for state, count in states:


### PR DESCRIPTION
Mostly removed unnecessary white space on blank lines, removed trailing white space, and shortened some lines that were over 80 characters using implicit string concatenation or method variable alignments. These changes were done on every file in the 'congress' subdirectory, with a few issues being left "as is" for convention or readability. Those items are detailed in the individual commits.